### PR TITLE
✨ Add FLOSS files and adjust README, Dockerfile

### DIFF
--- a/.woodpecker/.deploy.yaml
+++ b/.woodpecker/.deploy.yaml
@@ -2,7 +2,7 @@ steps:
   - name: deploy
     image: /bin/bash
     commands:
-      - fly deploy --remote-only 
+      - fly deploy --remote-only
     when:
       - branch: main
         event: push

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Code of Conduct
+
+As a contributor, you agree to follow the Code of Conduct outlined below when participating in our community and contributing to our project.
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at the address on the org's page. All complaints will be reviewed and investigated promptly and fairly. 
+
+All project team members are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+
+For answers to common questions about this code of conduct, see https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to creature-pigeon
+
+Welcome to **creature-pigeon**! We appreciate your interest in contributing. By participating in this project, you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## How to Contribute
+
+Contributions to **creature-pigeon** can come in many forms, including but not limited to:
+
+- Reporting bugs
+- Suggesting enhancements
+- Writing code patches
+- Improving documentation
+- Providing translations
+
+To contribute, follow these steps:
+
+1. **Fork** the repository and **clone** your fork locally.
+2. **Create a new branch** from `main` for your changes.
+3. **Install dependencies** if necessary (`npm install`).
+4. **Make your changes** and **test** thoroughly.
+5. **Commit** your changes with a descriptive commit message.
+6. **Push** your branch to your fork on GitHub.
+7. **Submit a pull request** (PR) to the `main` branch of the original repository.
+
+## Code Style
+
+- Follow the existing code style and conventions used in the project.
+- Ensure your code passes linting (`npm run lint`) and tests (`npm test`).
+
+## Reporting Issues
+
+If you encounter bugs or have suggestions for improvements, please [create an issue](https://github.com/apply-creatures/creature-shoveler/issues/new) on GitHub. Include details such as:
+
+- Steps to reproduce
+- Expected behavior
+- Actual behavior
+- Environment (e.g., Node.js version)
+
+## Pull Requests
+
+- PRs should address an existing issue or describe the purpose clearly.
+- Include necessary tests and ensure all tests pass.
+- Maintain a clean commit history with descriptive messages.
+- Reference related issues in your PR description using keywords (e.g., "Fixes #123").
+
+## Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [maintainers' email].
+
+## License
+
+By contributing to **creature-pigeon**, you agree that your contributions will be licensed under the license. See the [LICENSE](./LICENSE) file for more details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,10 @@ To contribute, follow these steps:
 ## Code Style
 
 - Follow the existing code style and conventions used in the project.
-- Ensure your code passes linting (`npm run lint`) and tests (`npm test`).
 
 ## Reporting Issues
 
-If you encounter bugs or have suggestions for improvements, please [create an issue](https://github.com/apply-creatures/creature-shoveler/issues/new) on GitHub. Include details such as:
+If you encounter bugs or have suggestions for improvements, please [create an issue](https://github.com/apply-creatures/creature-pigeon/issues/new) on GitHub. Include details such as:
 
 - Steps to reproduce
 - Expected behavior

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN chmod u+x /home/seed/.radicle/bin/git-remote-rad
 ENV RAD_PATH_EXPORT='export PATH="$PATH:/home/$USER/.radicle/bin"'
 ENV RAD_PATH="/home/${USER}/.radicle/bin:${PATH}"
 ENV RAD_HOME=/home/seed/.radicle/seed/
+ENV RAD_ALIAS=creature-pigeon
 
 # Uncomment this and have your own Radicle passphrase if you need to run locally
 # ENV RAD_PASSPHRASE=yoursecret
@@ -73,5 +74,9 @@ ENV REPO_DIR=/home/seed/.radicle/seed/creature-pigeon
 ENV RADICLE_REPO_STORAGE=/home/seed/.radicle/seed/storage/
 ENV REPO_NAME=creature-pigeon
 
+# Peers DID
+ENV RADICLE_PEER_ONE=did:key:z6MkmesFj9djBn5dyH4vMEAjZeBjCb1BYhKgBMtC2EeeknHn
+ENV RADICLE_PEER_TWO=did:key:z6MkttLTb5NFW3hdMcgTT6f7FW6m7gkE6kosR2uEhg8dJmb1
+ENV RADICLE_PEER_THREE=did:key:z6MknzVNznWdLv1Tj19pLzDsXF5D6SHhjWK6WiMCtop6FK4K
 
 ENTRYPOINT ["/initializer.sh"]

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ It would never end. I've done this work not just off dozens of other people's op
 [repo-size-shield]: https://img.shields.io/github/repo-size/apply-creatures/creatrue-pigeon?style=for-the-badge
 [repo-size-url]: https://github.com/apply-creatures/creature-pigeon/archive/refs/heads/main.zip
 [product-screenshot]: images/apply-creatures-logo.png
-[ci-shield]: https://ci.applycreatures.com/api/badges/2/status.svg
+[ci-shield]: https://ci.applycreatures.com/api/badges/5/status.svg
 [ci-url]: https://ci.applycreatures.com/repos/5
 [floss-shield]: https://www.bestpractices.dev/projects/9206/badge?style=for-the-badge
 [floss-url]: https://www.bestpractices.dev/projects/9206

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![repo-size][repo-size-shield]][repo-size-url]
 [![Contributors][contributors-shield]][contributors-url]
 [![license][license-shield]][license-url]
+[![ci][ci-shield]][ci-url]
+[![OpenSSF Best Practices][floss-shield]][floss-url]
 
 <!-- PROJECT LOGO -->
 <br />
@@ -199,6 +201,7 @@ Once you have successfully run you container locally or remotely, it is time to 
 
 **Note:** Make sure you stop your host Radicle node before performing these steps.
 
+
 1. Navigate to your Radicle directory (normally `.radicle`)
 ```bash
 # This directory contains all configurations and files needed to start your node
@@ -215,7 +218,7 @@ $ cd /path/to/.radicle
       "listen": ["0.0.0.0:8776"],
       ...
       "connect": ["<node-address>"],
-      "externalAddresses": ["<your-hostname>:<port>"],
+      "externalAddresses": ["<hostname>:<port>"],
       ...
    }
 }
@@ -230,7 +233,7 @@ $ rad node start # Start the host node
 
 4. Connect to the host Radicle seed node
 ```bash
-$ rad node connect <node-address>
+$ rad node connect <node-id@hostname:port>
 ```
 
 5. Verify if the connection is successful or not
@@ -280,10 +283,11 @@ If you want to know how to push, checkout or issue to the Radicle repository, yo
 
 - [x] Write a Dockerfile.
 - [x] Write a Shell Script for automating setups.
-- [x] Test on local machine.
+- [x] Have the container working on local machine.
 - [x] Deploy to a PaaS.
 - [x] Connect to deployed node from local machine.
 - [x] Persist the Radicle identity and its configurations.
+- [ ] Pass the FLOSS test (at least the "Passing badge")
 - [ ] Safeguard the container from security concerns.
 
 <hr/>
@@ -314,23 +318,27 @@ It would never end. I've done this work not just off dozens of other people's op
 
 <!-- Refs -->
 
-[codacy-url]: https://app.codacy.com/gh/apply-creatures/radicle-seed-node/dashboard
+[codacy-url]: https://app.codacy.com/gh/apply-creatures/creature-pigeon/dashboard
 [codacy-shield]: https://img.shields.io/codacy/grade/appid?style=for-the-badge
-[contributors-shield]: https://img.shields.io/github/contributors/apply-creatures/radicle-seed-node.svg?style=for-the-badge
-[contributors-url]: https://github.com/apply-creatures/radicle-seed-node/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/apply-creatures/radicle-seed-node.svg?style=for-the-badge
-[forks-url]: https://github.com/apply-creatures/radicle-seed-node/network/members
-[stars-shield]: https://img.shields.io/github/stars/apply-creatures/radicle-seed-node.svg?style=for-the-badge
-[stars-url]: https://github.com/apply-creatures/radicle-seed-node/stargazers
-[issues-shield]: https://img.shields.io/github/issues/apply-creatures/radicle-seed-node.svg?style=for-the-badge
-[issues-url]: https://github.com/apply-creatures/radicle-seed-node/issues
-[license-shield]: https://img.shields.io/github/license/apply-creatures/radicle-seed-node.svg?style=for-the-badge
-[license-url]: https://github.com/apply-creatures/radicle-seed-node/blob/main/LICENSE
-[score-shield]: https://img.shields.io/ossf-scorecard/github.com/apply-creatures/radicle-seed-node?style=for-the-badge
-[score-url]: https://github.com/apply-creatures/radicle-seed-node
-[repo-size-shield]: https://img.shields.io/github/repo-size/apply-creatures/radicle-seed-node?style=for-the-badge
-[repo-size-url]: https://github.com/apply-creatures/radicle-seed-node/archive/refs/heads/main.zip
+[contributors-shield]: https://img.shields.io/github/contributors/apply-creatures/creature-pigeon.svg?style=for-the-badge
+[contributors-url]: https://github.com/apply-creatures/creature-pigeon/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/apply-creatures/creature-pigeon.svg?style=for-the-badge
+[forks-url]: https://github.com/apply-creatures/creture-pigeon/network/members
+[stars-shield]: https://img.shields.io/github/stars/apply-creatures/creature-pigeon.svg?style=for-the-badge
+[stars-url]: https://github.com/apply-creatures/creature-pigeon/stargazers
+[issues-shield]: https://img.shields.io/github/issues/apply-creatures/creature-pigeon.svg?style=for-the-badge
+[issues-url]: https://github.com/apply-creatures/creature-pigeon/issues
+[license-shield]: https://img.shields.io/github/license/apply-creatures/creature-pigeon.svg?style=for-the-badge
+[license-url]: https://github.com/apply-creatures/creature-pigeon/blob/main/LICENSE
+[score-shield]: https://img.shields.io/ossf-scorecard/github.com/apply-creatures/creature-pigeon?style=for-the-badge
+[score-url]: https://github.com/apply-creatures/creature-pigeon
+[repo-size-shield]: https://img.shields.io/github/repo-size/apply-creatures/creatrue-pigeon?style=for-the-badge
+[repo-size-url]: https://github.com/apply-creatures/creature-pigeon/archive/refs/heads/main.zip
 [product-screenshot]: images/apply-creatures-logo.png
+[ci-shield]: https://ci.applycreatures.com/api/badges/2/status.svg
+[ci-url]: https://ci.applycreatures.com/repos/5
+[floss-shield]: https://www.bestpractices.dev/projects/9206/badge?style=for-the-badge
+[floss-url]: https://www.bestpractices.dev/projects/9206
 
 ## Changelog
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take security seriously. We appreciate your efforts to responsibly disclose any security concerns you may have found.
+
+To report a security vulnerability, please contact us privately at the email shown on the org page. We will review your report promptly and respond accordingly to address the issue.
+
+## Guidelines for Reporting
+
+When reporting vulnerabilities, please provide the following information:
+
+- Description of the vulnerability
+- Steps to reproduce the vulnerability
+- Proof-of-concept or exploit code (if applicable)
+- Your contact information for further communication
+
+## Response and Disclosure
+
+Once we receive your report, we will acknowledge its receipt and work with you to understand the scope and severity of the issue. We prioritize the security of our users and aim to provide timely updates and fixes.
+
+We appreciate your help in keeping **creature-pigeon** secure for everyone. Thank you for your responsible disclosure and cooperation.

--- a/fly.toml
+++ b/fly.toml
@@ -1,38 +1,42 @@
-# fly.toml app configuration file generated for creature-pigeon on 2024-07-09T19:29:56+07:00
-#
-# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
-#
+  # fly.toml app configuration file generated for creature-pigeon on 2024-07-12T16:24:23+07:00
+  #
+  # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+  #
 
-app = 'creature-pigeon'
-primary_region = 'waw'
+  app = 'creature-pigeon'
+  primary_region = 'waw'
 
-[build]
+  [build]
 
-[[mounts]]
-  source = 'radicle_volumes'
-  destination = '/home/seed/.radicle/seed'
-  initial_size = '1gb'
+  [[mounts]]
+    source = 'radicle_volumes'
+    destination = '/home/seed/.radicle/seed'
+    initial_size = '1gb'
+    processes = ['app']
 
-[http_service]
-  internal_port = 443
-  force_https = true
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
+  [http_service]
+    internal_port = 80
+    force_https = true
+    auto_stop_machines = true
+    auto_start_machines = true    
+    min_machines_running = 0
+    processes = ['app']
 
-[[services]]
-  protocol = 'tcp'
-  internal_port = 8776
-  auto_stop_machines = true
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
+  [[services]]
+    protocol = 'tcp'
+    internal_port = 8776
+    auto_stop_machines = true
+    auto_start_machines = true
 
-  [[services.ports]]
-    port = 8776
+    [[services.ports]]
+      port = 8776
+      handlers = ['tls']
 
-[[vm]]
-  memory = '1gb'
-  cpu_kind = 'shared'
-  cpus = 1
+    [[services.tcp_checks]]
+      interval = '5s'
+      timeout = '1s'
+
+  [[vm]]
+    memory = '1gb'
+    cpu_kind = 'shared'
+    cpus = 1

--- a/initializer.sh
+++ b/initializer.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-echo "RAD_PASSPHRASE is $RAD_PASSPHRASE"
-
 echo "Move the directory to the destination folder..."
 cp -r /home/seed/creature-pigeon /home/seed/.radicle/seed/
 
@@ -39,7 +37,7 @@ if [ -d $KEYS_DIR ]; then
     echo "Signed in Radicle identity successfully ✅." 
 else
     echo "The keys folder does not exist. Initializing new Radicle identity..."
-    rad auth --alias creature-radicle.fly.dev && echo "Initialized Radicle identity successfully ✅." 
+    rad auth --alias "$RAD_ALIAS.fly.dev" && echo "Initialized Radicle identity successfully ✅." 
     rad self
 
     # Navigate to the seed folder
@@ -67,6 +65,10 @@ echo "Starting the Radicle node..."
 rad node start
 
 echo "Started the Radicle node successfully! 🥳"
+
+rad node status 
+
+rad config 
 
 # Display the Radicle node address
 echo "Your Radicle node address is $(rad node config --addresses)."
@@ -114,28 +116,28 @@ cd ~/.radicle/seed/creature-pigeon
 
 
         # Peers ID
-        bachiro_one_did=did:key:z6MkmesFj9djBn5dyH4vMEAjZeBjCb1BYhKgBMtC2EeeknHn
-        bachiro_two_did=did:key:z6MkttLTb5NFW3hdMcgTT6f7FW6m7gkE6kosR2uEhg8dJmb1
-        hirako_did=did:key:z6MknzVNznWdLv1Tj19pLzDsXF5D6SHhjWK6WiMCtop6FK4K 
+        peer_one=$RADICLE_PEER_ONE
+        peer_two=$RADICLE_PEER_TWO
+        peer_three=$RADICL_PEER_THREE 
 
         # Seed the Radicle repository
         rad seed $(rad .) --scope followed
 
         # Follow to peers
-        rad follow $bachiro_one_did
-        rad follow $bachiro_two_did
-        rad follow $hirako_did
+        rad follow $peer_one
+        rad follow $peer_two
+        rad follow $peer_three
                     
         # Register peers to the repository  
         echo "Registering peers..."
         rad id update --title "Update node delegate and access" \
                     --description "Add peers as new delegates and permit access to the repository." \
-                    --delegate $bachiro_two_did \
-                    --delegate $bachiro_one_did \
-                    --delegate $hirako_did \
-                    --allow $bachiro_two_did \
-                    --allow $bachiro_one_did \
-                    --allow $hirako_did \
+                    --delegate $peer_one \
+                    --delegate $peer_two \
+                    --delegate $peer_three \
+                    --allow $peer_one \
+                    --allow $peer_two \
+                    --allow $peer_three \
                     --no-confirm 
 
 

--- a/licenses/MIT.txt
+++ b/licenses/MIT.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Hirako, Apply Creatures
+Copyright (c) 2024 Bachiro, Apply Creatures
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Motivation and Context

FLOS related or just repo documentation template are missing. The peers ID are hard-coded inside shell script. It would be better if those IDs are set outside the script to be more easier to interchange with other peer IDs.

### Description

1. Add the Code of Conduct, Contributing, Securtiy files to pass more criteria in the passing tier.

2. Add FLOSS badge to the README file.

3. Move peers ID from the shell script to Dockerfile to remove hard-coding peers' node ids.